### PR TITLE
fix(tests): CI-safe los tests que dependian de DML untracked

### DIFF
--- a/tests/fastapi/core/test_mundial_cli.py
+++ b/tests/fastapi/core/test_mundial_cli.py
@@ -2,10 +2,23 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 
-def test_new_theme_mundial_runs_sql_syncs_and_warms():
+def test_new_theme_mundial_runs_sql_syncs_and_warms(tmp_path):
+    # Los SQL reales viven en database/DML/core/themes/mundial/, que está
+    # gitignored y NO existe en un clon limpio (CI). Para que el test sea
+    # autocontenido y corra en cualquier lado, creamos fixtures de SQL en un
+    # PROJECT_ROOT temporal y lo parcheamos. execute_sql_file va mockeado, así
+    # que el contenido de los .sql no importa: solo que el glob los encuentre.
+    mundial_dir = tmp_path / "database" / "DML" / "core" / "themes" / "mundial"
+    mundial_dir.mkdir(parents=True)
+    (mundial_dir / "01_theme.sql").write_text("-- theme")
+    (mundial_dir / "02_task.sql").write_text("-- task")
+
+    from itcj2.cli import core as cli_core
     from itcj2.cli.core import new_theme_mundial_command
+
     runner = CliRunner()
-    with patch("itcj2.cli.core.execute_sql_file") as mock_exec, \
+    with patch.object(cli_core, "PROJECT_ROOT", tmp_path), \
+         patch("itcj2.cli.core.execute_sql_file") as mock_exec, \
          patch("itcj2.cli.core._get_session") as mock_sess, \
          patch("itcj2.core.services.themes_service.invalidate_active_theme_cache") as mock_invalidate, \
          patch("itcj2.core.services.mundial_service.sync_periodic_task", return_value=True) as mock_sync, \

--- a/tests/fastapi/maint/config/test_config_skeleton.py
+++ b/tests/fastapi/maint/config/test_config_skeleton.py
@@ -245,7 +245,16 @@ class TestSeedConfigCli:
 
     def test_seed_config_with_real_config_dir_calls_execute_sql_at_least_once(self):
         """Con la carpeta real database/DML/maint/config/ (01_insert_permissions.sql),
-        execute_sql_file se invoca al menos una vez."""
+        execute_sql_file se invoca al menos una vez.
+
+        database/ está gitignored → en un clon limpio (CI) la carpeta no existe.
+        Este test valida la presencia/orden del DML REAL, así que se salta si la
+        carpeta no está (no aplica en CI; sí corre local donde los .sql existen).
+        """
+        import pytest
+        from itcj2.cli.maint import DML_MAINT
+        if not (Path(DML_MAINT) / "config").is_dir():
+            pytest.skip("database/DML/maint/config/ untracked — ausente en CI")
         with patch("itcj2.cli.core.execute_sql_file") as mock_exec:
             from itcj2.cli.maint import _seed_config_files
             count = _seed_config_files()


### PR DESCRIPTION
database/ esta gitignored -> en un clon limpio (CI) los .sql no existen y 2 tests truenaban, bloqueando el gate de deploy.
- test_mundial_cli: ahora crea fixtures SQL en un PROJECT_ROOT temporal y lo parchea (autocontenido, corre en CI).
- test_seed_config_with_real_config_dir: skipea si database/DML/maint/config/ no existe (valida el DML real solo cuando esta presente, p.ej. local).